### PR TITLE
Fix bug in matching service rank algorithm

### DIFF
--- a/src/main/java/com/revature/rideshare/matching/services/MatchService.java
+++ b/src/main/java/com/revature/rideshare/matching/services/MatchService.java
@@ -87,7 +87,7 @@ public class MatchService {
 	private double rankMatch(User rider, User driver) {
 		// Right now, this only takes distance into consideration.
 		Route riderToDriver = mapsClient.getRoute(rider.getAddress(), driver.getAddress());
-		return 1 / (riderToDriver.getDistance() + 1);
+		return 1 / ((double) riderToDriver.getDistance() + 1);
 	}
 
 	/**


### PR DESCRIPTION
The rank was being calculated as a `long`, which meant that it was pretty much useless (it would be 1 for someone living at the exact same location and 0 otherwise). Now it's being properly calculated as a `double`.