### PR TITLE
Fixed Compilation issue with MatchServiceRoute

### DIFF
--- a/src/main/java/com/revature/rideshare/matching/services/MatchService.java
+++ b/src/main/java/com/revature/rideshare/matching/services/MatchService.java
@@ -189,20 +189,10 @@ public class MatchService {
 	 */
 	private double rankByDistance(User rider, User driver) {
 		// TODO: This could be null based on the MapClient service.
-		// This is a patch job as even though a Route is sent from the Map Service, it is received as a LinkedHashMap. 
 		// TODO: Proper handling of error conditions can be done Monday
-		LinkedHashMap routeMap = (LinkedHashMap) mapsClient.getRoute(rider.getAddress(), driver.getAddress()).getBody();
-		Route riderToDriver = new Route((long)(int)routeMap.get("distance"), (long)(int)routeMap.get("duration"));
+		Route riderToDriver = mapsClient.getRoute(rider.getAddress(), driver.getAddress());
 		return 1 / ((double) riderToDriver.getDistance() + 1);
 	}
-	
-	
-//	public void testRoute() {
-//		LinkedHashMap routeMap = (LinkedHashMap) mapsClient.getRoute("1234 asdf", " 1234 qwer").getBody();
-//		Route riderToDriver = new Route((long)(int)routeMap.get("distance"), (long)(int)routeMap.get("duration"));
-////		Route riderToDriver = new Route((Long)((LinkedHashMap) o).get("distance"), (Long)((LinkedHashMap) o).get("duration"));
-//		System.out.println(riderToDriver);
-//	}
 	
 
 	/**


### PR DESCRIPTION
I Fixed the issue that was causing the MatchService to not compile. When the feign client signature was changed to return Route objects, the service was still expecting a ResponseEntity with a LinkedHashMap for the body. 